### PR TITLE
feat: add cnpj authentication for bakeries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ docker run --name sindpan-auth \
 ```
 
 ## Endpoints
-- `POST /auth/register` — `{ email, password, bakery_name? }`
-- `POST /auth/login` — `{ email, password }`
+- `POST /auth/register` — `{ email?, cnpj?, password, bakery_name? }`
+- `POST /auth/login` — `{ email?, cnpj?, password }`
 - `GET /auth/me` — Authorization: `Bearer <token>`
 
 ## Admin opcional

--- a/src/auth.js
+++ b/src/auth.js
@@ -3,27 +3,33 @@ import jwt from 'jsonwebtoken';
 import { query } from './db.js';
 
 function signTokens(user) {
-  const payload = { sub: user.id, role: user.role, email: user.email };
+  const payload = { sub: user.id, role: user.role, email: user.email, cnpj: user.cnpj };
   const accessToken = jwt.sign(payload, process.env.JWT_SECRET, {
     expiresIn: process.env.JWT_EXPIRES || '15m'
   });
   return { accessToken };
 }
 
-export async function createUser({ email, password, role = 'bakery', bakery_name = null }) {
+export async function createUser({ email = null, cnpj = null, password, role = 'bakery', bakery_name = null }) {
+  if (!email && !cnpj) throw new Error('email or cnpj is required');
   const rounds = parseInt(process.env.BCRYPT_SALT_ROUNDS || '12', 10);
   const password_hash = await bcrypt.hash(password, rounds);
   const result = await query(
-    `INSERT INTO users(email, password_hash, role, bakery_name)
-     VALUES ($1, $2, $3, $4)
-     RETURNING id, email, role, bakery_name, created_at`,
-    [email.toLowerCase(), password_hash, role, bakery_name]
+    `INSERT INTO users(email, cnpj, password_hash, role, bakery_name)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, email, cnpj, role, bakery_name, created_at`,
+    [email ? email.toLowerCase() : null, cnpj, password_hash, role, bakery_name]
   );
   return result.rows[0];
 }
 
 export async function findUserByEmail(email) {
   const result = await query(`SELECT * FROM users WHERE email = $1`, [email.toLowerCase()]);
+  return result.rows[0] || null;
+}
+
+export async function findUserByCnpj(cnpj) {
+  const result = await query(`SELECT * FROM users WHERE cnpj = $1`, [cnpj]);
   return result.rows[0] || null;
 }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -6,7 +6,7 @@ export function requireAuth(req, res, next) {
   if (!token) return res.status(401).json({ error: 'Missing token' });
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = payload; // { sub, role, email }
+    req.user = payload; // { sub, role, email?, cnpj? }
     return next();
   } catch {
     return res.status(401).json({ error: 'Invalid or expired token' });

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { requireAuth } from './middleware.js';
-import { createUser, findUserByEmail, validatePassword, signTokens } from './auth.js';
+import { createUser, findUserByEmail, findUserByCnpj, validatePassword, signTokens } from './auth.js';
 import { query } from './db.js';
 
 const router = express.Router();
@@ -10,15 +10,24 @@ router.get('/health', (_, res) => res.json({ ok: true }));
 // Cadastro: padaria self-service
 router.post('/auth/register', async (req, res) => {
   try {
-    const { email, password, bakery_name } = req.body || {};
-    if (!email || !password) return res.status(400).json({ error: 'email and password are required' });
+    const { email, cnpj, password, bakery_name } = req.body || {};
+    if ((!email && !cnpj) || !password) {
+      return res.status(400).json({ error: 'email or cnpj and password are required' });
+    }
 
-    const exists = await findUserByEmail(email);
-    if (exists) return res.status(409).json({ error: 'email already registered' });
+    if (email) {
+      const existsEmail = await findUserByEmail(email);
+      if (existsEmail) return res.status(409).json({ error: 'email already registered' });
+    }
 
-    const user = await createUser({ email, password, role: 'bakery', bakery_name });
+    if (cnpj) {
+      const existsCnpj = await findUserByCnpj(cnpj);
+      if (existsCnpj) return res.status(409).json({ error: 'cnpj already registered' });
+    }
+
+    const user = await createUser({ email, cnpj, password, role: 'bakery', bakery_name });
     const tokens = signTokens(user);
-    res.status(201).json({ user: { id: user.id, email: user.email, role: user.role, bakery_name: user.bakery_name }, ...tokens });
+    res.status(201).json({ user: { id: user.id, email: user.email, cnpj: user.cnpj, role: user.role, bakery_name: user.bakery_name }, ...tokens });
   } catch (e) {
     res.status(500).json({ error: 'internal_error' });
   }
@@ -27,17 +36,26 @@ router.post('/auth/register', async (req, res) => {
 // Login: padaria ou admin
 router.post('/auth/login', async (req, res) => {
   try {
-    const { email, password } = req.body || {};
-    if (!email || !password) return res.status(400).json({ error: 'email and password are required' });
+    const { email, cnpj, password } = req.body || {};
+    if ((!email && !cnpj) || !password) {
+      return res.status(400).json({ error: 'email or cnpj and password are required' });
+    }
 
-    const user = await findUserByEmail(email);
+    let user;
+    if (email) {
+      user = await findUserByEmail(email);
+    } else {
+      user = await findUserByCnpj(cnpj);
+      if (user && user.role !== 'bakery') user = null;
+    }
+
     if (!user) return res.status(401).json({ error: 'invalid_credentials' });
 
     const ok = await validatePassword(password, user.password_hash);
     if (!ok) return res.status(401).json({ error: 'invalid_credentials' });
 
     const tokens = signTokens(user);
-    res.json({ user: { id: user.id, email: user.email, role: user.role, bakery_name: user.bakery_name }, ...tokens });
+    res.json({ user: { id: user.id, email: user.email, cnpj: user.cnpj, role: user.role, bakery_name: user.bakery_name }, ...tokens });
   } catch {
     res.status(500).json({ error: 'internal_error' });
   }
@@ -45,7 +63,7 @@ router.post('/auth/login', async (req, res) => {
 
 // Perfil do usuário autenticado
 router.get('/auth/me', requireAuth, async (req, res) => {
-  const { rows } = await query(`SELECT id, email, role, bakery_name, created_at FROM users WHERE id = $1`, [req.user.sub]);
+  const { rows } = await query(`SELECT id, email, cnpj, role, bakery_name, created_at FROM users WHERE id = $1`, [req.user.sub]);
   res.json({ user: rows[0] });
 });
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -2,12 +2,15 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  email TEXT UNIQUE NOT NULL,
+  email TEXT UNIQUE,
+  cnpj TEXT UNIQUE,
   password_hash TEXT NOT NULL,
   role TEXT NOT NULL CHECK (role IN ('bakery', 'admin')),
   bakery_name TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (email IS NOT NULL OR cnpj IS NOT NULL)
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_cnpj ON users(cnpj);
 CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);


### PR DESCRIPTION
## Summary
- allow bakery users to register and log in with CNPJ as an alternative to email
- store CNPJ in users table and include it in JWT payloads and responses
- document new CNPJ-based endpoints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b73efae3ec832a911ac4f454daa30a